### PR TITLE
Update to reflect most recent 0.8.0 Changes

### DIFF
--- a/en/files.md
+++ b/en/files.md
@@ -74,10 +74,8 @@ Output
 ━━━┷━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━
 ```
 
-You can alternatively do this using `read`.
+You can alternatively do this using `parse`.
 
-`open bands.txt | read "{Band}:{Album}:{Year}" | skip 1 | sort-by Year`
-
-`open bands.txt | parse "{Band}:{Album}:{Year}" | skip 1 | sort-by Year` *master only*
+`open bands.txt | parse "{Band}:{Album}:{Year}" | skip 1 | sort-by Year`
 
 ---

--- a/en/git.md
+++ b/en/git.md
@@ -47,7 +47,7 @@ Output
 
 ---
 
-### View git comitter activity as a `histogram` *master-only*
+### View git comitter activity as a `histogram`
 
 `git log "--pretty=format:%h<nu>%aN<nu>%s<nu>%aD" | lines | split-column "<nu>" sha1 committer desc  merged_at | histogram committer merger | sort-by merger | reverse`
 

--- a/en/parsing.md
+++ b/en/parsing.md
@@ -9,13 +9,9 @@ link_next: /en/native_shell_programs.html
 
 Nu offers the ability to do some basic parsing.
 
-
 How to parse an arbitrary pattern from a string of text into a multi-column table.
-Note that for version `0.5.0` the parsing command is called `read`, while the next version of nushell it will be renamed to `parse`.
 
-`cargo search shells --limit 10 | lines | read "{crate_name} = {version} #{description}"`
-
-`cargo search shells --limit 10 | lines | parse "{crate_name} = {version} #{description}"` *master-only*
+`cargo search shells --limit 10 | lines | parse "{crate_name} = {version} #{description}"`
 
 Output
 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ title: Cookbook
 
 This Nu Cookbook is a collection of examples to help you get the most out of using Nushell.
 Unless otherwise noted,
-all _recipies_ are available in the `0.5.0` version of Nu with `--all-features` enabled.
+all _recipies_ are available in the `0.8.0` version of Nu with `--features=stable` enabled.
 Recipies marked with  `master-only` are available when nushell is built from source using the `master` branch.
 
 While this cookbook is a series of examples to help get you started,


### PR DESCRIPTION
Removes any `*master only*` from places where the code works on `0.8.0` with `--features=stable`. For the future, we may want to think about adding some sort of feedback to show if a recipe uses a plugin not in `--features=stables`.