### PR TITLE
Updated config set commands in setup.md

### DIFF
--- a/en/setup.md
+++ b/en/setup.md
@@ -16,7 +16,7 @@ however setting up your nu configuration will make it much easier as these are s
 
 ### Configure your path
 
-`config --set [path $nu.path]`
+`config set path $nu.path`
 
 Output
 
@@ -32,7 +32,7 @@ Output
 
 ### Configure your environment variables
 
-`config --set [env $nu.env]`
+`config set env $nu.env`
 
 Output
 


### PR DESCRIPTION
I'm following the cookbook in nushell 0.19.0 and had to use `config set var value` instead of `config --set [var value]`.