### PR TITLE
update git parsing to use parens and update the split command

### DIFF
--- a/en/git.md
+++ b/en/git.md
@@ -23,7 +23,7 @@ Deleted branch post-argument-positions (was 9d34ec9).
 
 Parse formatted commit messages
 
-`git log "--pretty=format:%h<nu>%aN<nu>%s<nu>%aD" | lines | split-column "<nu>" sha1 committer desc merged_at | first 10`
+`git log "--pretty=format:%h(nu)%aN(nu)%s(nu)%aD" | lines | split column "(nu)" sha1 committer desc merged_at | first 10`
 
 
 Output
@@ -49,7 +49,7 @@ Output
 
 ### View git comitter activity as a `histogram`
 
-`git log "--pretty=format:%h<nu>%aN<nu>%s<nu>%aD" | lines | split-column "<nu>" sha1 committer desc  merged_at | histogram committer merger | sort-by merger | reverse`
+`git log "--pretty=format:%h(nu)%aN(nu)%s(nu)%aD" | lines | split column "(nu)" sha1 committer desc  merged_at | histogram committer merger | sort-by merger | reverse`
 
 ```
 ━━━━┯━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
This PR addresses the issue [#2227](https://github.com/nushell/nushell/issues/2227) in the main nushell repository. The git command was no longer working while using `<nu>` as the separator. Changing it to `(nu)` and updating the deprecated `split-column` to `split column` fixes the issue in nu version `0.19`