### PR TITLE
Fix pick to select rename

### DIFF
--- a/en/setup.md
+++ b/en/setup.md
@@ -116,7 +116,7 @@ Output
 
 or 
 
-`config | get env | pick APPDATA`
+`config | get env | select APPDATA`
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
In version 0.13.0 `pick` was renamed to `select`. This change fixes an
example that wasn't renamed.